### PR TITLE
[VIT-1762] Fix Quickstart display most recent users front end

### DIFF
--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -12,7 +12,7 @@ const Home: NextPage = () => {
   const [userID, setUserID] = useState(null);
   const { data } = useSWR("/users/", fetcher);
 
-  const usersFiltered = data?.users ? (data.total > 0 ? data.users : []) : [];
+  const usersFiltered = data?.users ? data.users : [];
 
   return (
     <VStack

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -10,9 +10,9 @@ import { ActivityPanel } from "../components/dashboard/ActivityPanel";
 
 const Home: NextPage = () => {
   const [userID, setUserID] = useState(null);
-  const { data: users } = useSWR("/users/", fetcher);
+  const { data } = useSWR("/users/", fetcher);
 
-  const usersFiltered = users ? (users?.length > 0 ? users : []) : [];
+  const usersFiltered = data?.users ? (data.total > 0 ? data.users : []) : [];
 
   return (
     <VStack


### PR DESCRIPTION
Updated the front end to account for a change to the user API response structure- the most recent users were not being displayed. 
Tested manually by checking data is displayed in the front end. Overseen by Carlos.